### PR TITLE
ci: initial setup (build / tests / clippy / fmt)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# This file instructs git to ignore specific commits when using blame
+# github uses it automatically, but it needs a manual action on local
+# repositories:
+# git config blame.ignoreRevsFile .git-blame-ignore-revs 
+
+# Apply cargo fmt
+85bcab66749bcf97db5a3623f78e19cd8146db07

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,41 @@
+name: Rust
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo
+          target/
+        key: ${{ runner.os }}-${{ hashFiles('Cargo.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ hashFiles('Cargo.toml') }}
+          ${{ runner.os }}-
+    - name: Build
+      run: cargo build --verbose
+    - name: Clippy
+      run: cargo clippy -- -D warnings
+    - name: Format
+      run: cargo fmt --check
+    - name: Run tests
+      run: |
+        cargo test --verbose
+        cargo run --example nominal
+
+      
+

--- a/examples/nominal.rs
+++ b/examples/nominal.rs
@@ -1,70 +1,70 @@
-use actix_web::{App, web, Responder,
-  HttpResponse, get, test};
-use biscuit_auth::{Biscuit, KeyPair, 
-  macros::{biscuit, authorizer}};
+use actix_web::{get, test, web, App, HttpResponse, Responder};
 use biscuit_actix_middleware::BiscuitMiddleware;
+use biscuit_auth::{
+    macros::{authorizer, biscuit},
+    Biscuit, KeyPair,
+};
 
 #[get("/hello-admin")]
 async fn hello_admin(token: web::ReqData<Biscuit>) -> impl Responder {
-  // authorizer that allow only if role is admin
-  let mut authorizer = authorizer!(
-    r#"
+    // authorizer that allow only if role is admin
+    let mut authorizer = authorizer!(
+        r#"
       allow if role("admin");
     "#
-  );
+    );
 
-  // link authorizer and token
-  if authorizer.add_token(&token).is_err() {
-    return HttpResponse::InternalServerError().finish()
-  }
+    // link authorizer and token
+    if authorizer.add_token(&token).is_err() {
+        return HttpResponse::InternalServerError().finish();
+    }
 
-  // check authorization
-  if authorizer.authorize().is_err() {
-    return HttpResponse::Forbidden().finish()
-  }
+    // check authorization
+    if authorizer.authorize().is_err() {
+        return HttpResponse::Forbidden().finish();
+    }
 
-  HttpResponse::Ok().body("Hello admin!")
+    HttpResponse::Ok().body("Hello admin!")
 }
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-  let root = KeyPair::new();
-  let user_role = "admin";
+    let root = KeyPair::new();
+    let user_role = "admin";
 
-  // instantiate a new biscuit
-  let biscuit = biscuit!(
-    r#"
+    // instantiate a new biscuit
+    let biscuit = biscuit!(
+        r#"
       role({user_role});
-    "#).build(&root)
+    "#
+    )
+    .build(&root)
     .unwrap();
 
-  // serialize biscuit into a token
-  let biscuit_token = biscuit
-    .to_base64()
-    .unwrap();
+    // serialize biscuit into a token
+    let biscuit_token = biscuit.to_base64().unwrap();
 
-  println!("Biscuit token: {}", biscuit_token);
+    println!("Biscuit token: {}", biscuit_token);
 
-  // instantiate app using actix test tools
-  let app = test::init_service(
-    App::new()
-      .wrap(BiscuitMiddleware{
-        public_key: root.public()
-      }).service(hello_admin)
-  ).await;
-  
-  // test request with authorization header
-  let req = test::TestRequest::get()
-    .insert_header((
-      "authorization",
-      String::from("Bearer ") + &biscuit_token
-    ))
-    .uri("/hello-admin")
-    .to_request();
-  
-  let response = test::call_service(&app, req).await;
+    // instantiate app using actix test tools
+    let app = test::init_service(
+        App::new()
+            .wrap(BiscuitMiddleware {
+                public_key: root.public(),
+            })
+            .service(hello_admin),
+    )
+    .await;
 
-  println!("Response status: {}", response.status());
+    // test request with authorization header
+    let req = test::TestRequest::get()
+        .insert_header(("authorization", String::from("Bearer ") + &biscuit_token))
+        .uri("/hello-admin")
+        .to_request();
 
-  Ok(())
+    let response = test::call_service(&app, req).await;
+
+    println!("Response status: {}", response.status());
+
+    Ok(())
 }

--- a/examples/nominal.rs
+++ b/examples/nominal.rs
@@ -14,12 +14,12 @@ async fn hello_admin(token: web::ReqData<Biscuit>) -> impl Responder {
   );
 
   // link authorizer and token
-  if let Err(_) = authorizer.add_token(&token) {
+  if authorizer.add_token(&token).is_err() {
     return HttpResponse::InternalServerError().finish()
   }
 
   // check authorization
-  if let Err(_) = authorizer.authorize() {
+  if authorizer.authorize().is_err() {
     return HttpResponse::Forbidden().finish()
   }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,23 +1,19 @@
+use actix_web::{error::ResponseError, HttpResponse};
 use derive_more::Display;
-use actix_web::{error::{ResponseError}, HttpResponse};
 
 pub type MiddlewareResult<R> = Result<R, MiddlewareError>;
 
 #[derive(Debug, Display)]
 pub enum MiddlewareError {
-  InvalidHeader,
-  InvalidToken,
+    InvalidHeader,
+    InvalidToken,
 }
 
 impl ResponseError for MiddlewareError {
-  fn error_response(&self) -> HttpResponse {
-    match self {
-      MiddlewareError::InvalidHeader => {
-        HttpResponse::Unauthorized().finish()
-      }
-      MiddlewareError::InvalidToken => {
-        HttpResponse::Forbidden().finish()
-      }
+    fn error_response(&self) -> HttpResponse {
+        match self {
+            MiddlewareError::InvalidHeader => HttpResponse::Unauthorized().finish(),
+            MiddlewareError::InvalidToken => HttpResponse::Forbidden().finish(),
+        }
     }
-  }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-mod middleware;
 mod error;
+mod middleware;
 
 extern crate biscuit_auth as biscuit;
 

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -93,12 +93,12 @@ impl<S> ImplBiscuitMiddleware<S> {
       .token();
 
     // deserialize token into a biscuit
-    Ok(Biscuit::from_base64(token, self.public_key)
+    Biscuit::from_base64(token, self.public_key)
       .map_err(|_e| {
         #[cfg(feature = "tracing")]
         warn!("{}", _e.to_string());
         MiddlewareError::InvalidToken
-      })?)
+      })
   }
 }
 

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,29 +1,30 @@
-use std::{future::{ready, Ready}};
-use biscuit::{Biscuit, PublicKey};
+use crate::error::{MiddlewareError, MiddlewareResult};
 use actix_web::{
+    body::EitherBody,
     dev::{forward_ready, Service, ServiceRequest, ServiceResponse, Transform},
-    Error, body::EitherBody, HttpMessage, ResponseError,
-    http::header::Header
+    http::header::Header,
+    Error, HttpMessage, ResponseError,
 };
 use actix_web_httpauth::headers::authorization::{Authorization, Bearer};
-#[cfg(feature = "tracing")]
-use tracing::{warn};
-use crate::error::{MiddlewareError, MiddlewareResult};
+use biscuit::{Biscuit, PublicKey};
 use futures_util::future::LocalBoxFuture;
+use std::future::{ready, Ready};
+#[cfg(feature = "tracing")]
+use tracing::warn;
 
 /// On incoming request if there is a valid [bearer token](https://developer.mozilla.org/fr/docs/Web/HTTP/Authentication#bearer) authorization header:
 /// - deserialize it using public key attribute
 /// - inject a biscuit as extension in handler
-/// 
+///
 /// else return an Unauthorized (invalid header format) or Forbidden (deserialization error)
 /// with an error message in the body
-/// 
+///
 /// ```rust
 ///  use actix_web::{App, web,
 ///   HttpResponse, get, HttpServer};
 ///  use biscuit_auth::{Biscuit, KeyPair};
 ///  use biscuit_actix_middleware::BiscuitMiddleware;
-/// 
+///
 ///  #[actix_web::main]
 ///  async fn main() -> std::io::Result<()> {
 ///    let root = KeyPair::new();
@@ -38,7 +39,7 @@ use futures_util::future::LocalBoxFuture;
 ///     .bind(("127.0.0.1", 8080))?;
 ///     //.run()
 ///     //.await;
-/// 
+///
 ///     Ok(())
 ///   }
 ///   
@@ -51,191 +52,173 @@ use futures_util::future::LocalBoxFuture;
 /// ```
 
 pub struct BiscuitMiddleware {
-  pub public_key: PublicKey
+    pub public_key: PublicKey,
 }
 
 impl<S, B> Transform<S, ServiceRequest> for BiscuitMiddleware
 where
-  S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
-  S::Future: 'static,
-  B: 'static,
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S::Future: 'static,
+    B: 'static,
 {
-  type Response = ServiceResponse<EitherBody<B>>;
-  type Error = Error;
-  type InitError = ();
-  type Transform = ImplBiscuitMiddleware<S>;
-  type Future = Ready<Result<Self::Transform, Self::InitError>>;
+    type Response = ServiceResponse<EitherBody<B>>;
+    type Error = Error;
+    type InitError = ();
+    type Transform = ImplBiscuitMiddleware<S>;
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
 
-  fn new_transform(&self, service: S) -> Self::Future {
-    ready(Ok(
-      ImplBiscuitMiddleware { 
-        service, 
-        public_key: self.public_key 
-    }))
-  }
+    fn new_transform(&self, service: S) -> Self::Future {
+        ready(Ok(ImplBiscuitMiddleware {
+            service,
+            public_key: self.public_key,
+        }))
+    }
 }
 
 pub struct ImplBiscuitMiddleware<S> {
-  service: S,
-  public_key: PublicKey
+    service: S,
+    public_key: PublicKey,
 }
 
 impl<S> ImplBiscuitMiddleware<S> {
-  fn extract_biscuit(&self, req: &ServiceRequest) -> MiddlewareResult<Biscuit> {
-    // extract token 
-    let header_value = Authorization::<Bearer>::parse(req)
-      .map_err(|_e| {
-        #[cfg(feature = "tracing")]
-        warn!("{}", _e.to_string());
-        MiddlewareError::InvalidHeader
-      })?;
-    let token = header_value.as_ref()
-      .token();
+    fn extract_biscuit(&self, req: &ServiceRequest) -> MiddlewareResult<Biscuit> {
+        // extract token
+        let header_value = Authorization::<Bearer>::parse(req).map_err(|_e| {
+            #[cfg(feature = "tracing")]
+            warn!("{}", _e.to_string());
+            MiddlewareError::InvalidHeader
+        })?;
+        let token = header_value.as_ref().token();
 
-    // deserialize token into a biscuit
-    Biscuit::from_base64(token, self.public_key)
-      .map_err(|_e| {
-        #[cfg(feature = "tracing")]
-        warn!("{}", _e.to_string());
-        MiddlewareError::InvalidToken
-      })
-  }
+        // deserialize token into a biscuit
+        Biscuit::from_base64(token, self.public_key).map_err(|_e| {
+            #[cfg(feature = "tracing")]
+            warn!("{}", _e.to_string());
+            MiddlewareError::InvalidToken
+        })
+    }
 }
 
 impl<S, B> Service<ServiceRequest> for ImplBiscuitMiddleware<S>
 where
-  S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
-  S::Future: 'static,
-  B: 'static,
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S::Future: 'static,
+    B: 'static,
 {
-  type Response = ServiceResponse<EitherBody<B>>;
-  type Error = Error;
-  type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
+    type Response = ServiceResponse<EitherBody<B>>;
+    type Error = Error;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
 
-  forward_ready!(service);
+    forward_ready!(service);
 
-  fn call(&self, req: ServiceRequest) -> Self::Future {
-    match self.extract_biscuit(&req) {
-      Ok(biscuit) => {
-        req.extensions_mut().insert(biscuit);
-        let fut = self.service.call(req);
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        match self.extract_biscuit(&req) {
+            Ok(biscuit) => {
+                req.extensions_mut().insert(biscuit);
+                let fut = self.service.call(req);
 
-        Box::pin(async move {
-          let res = fut.await?;
-          Ok(res.map_into_left_body())
-        })
-      },
-      Err(e) => {
-        Box::pin(async move {
-          let r = req.into_response(e.error_response()).map_into_right_body::<B>();
-          Ok(r)
-        })
-      }
+                Box::pin(async move {
+                    let res = fut.await?;
+                    Ok(res.map_into_left_body())
+                })
+            }
+            Err(e) => Box::pin(async move {
+                let r = req
+                    .into_response(e.error_response())
+                    .map_into_right_body::<B>();
+                Ok(r)
+            }),
+        }
     }
-  }
 }
 
 #[cfg(test)]
 mod test {
-  use actix_web::{test, App, web, HttpResponse,
-  http::StatusCode};
-  use super::*;
-  use biscuit::KeyPair;
+    use super::*;
+    use actix_web::{http::StatusCode, test, web, App, HttpResponse};
+    use biscuit::KeyPair;
 
-  #[actix_web::test]
-  async fn test_nominal() {
-    let root = KeyPair::new();
-    let app = test::init_service(
-      App::new()
-        .wrap(BiscuitMiddleware{public_key: root.public()})
-        .service(
-          web::resource("/test")
-            .route(web::get().to(handler_biscuit_token_test))
+    #[actix_web::test]
+    async fn test_nominal() {
+        let root = KeyPair::new();
+        let app = test::init_service(
+            App::new()
+                .wrap(BiscuitMiddleware {
+                    public_key: root.public(),
+                })
+                .service(web::resource("/test").route(web::get().to(handler_biscuit_token_test))),
         )
-    ).await;
+        .await;
 
-    let biscuit = Biscuit::builder()
-      .build(&root)
-      .unwrap();
-    let req = test::TestRequest::get()
-      .insert_header((
-        "authorization",
-        String::from("Bearer ") + &biscuit.to_base64().unwrap()
-      ))
-      .uri("/test")
-      .to_request();
-    let resp = test::call_service(&app, req).await;
+        let biscuit = Biscuit::builder().build(&root).unwrap();
+        let req = test::TestRequest::get()
+            .insert_header((
+                "authorization",
+                String::from("Bearer ") + &biscuit.to_base64().unwrap(),
+            ))
+            .uri("/test")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
 
-    assert_eq!(resp.status(), StatusCode::OK);
-  }
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
 
-  #[actix_web::test]
-  async fn test_header_missing() {
-    let root = KeyPair::new();
-    let app = test::init_service(
-      App::new()
-        .wrap(BiscuitMiddleware{public_key: root.public()})
-        .service(
-          web::resource("/test")
-            .route(web::get().to(handler_biscuit_token_test))
+    #[actix_web::test]
+    async fn test_header_missing() {
+        let root = KeyPair::new();
+        let app = test::init_service(
+            App::new()
+                .wrap(BiscuitMiddleware {
+                    public_key: root.public(),
+                })
+                .service(web::resource("/test").route(web::get().to(handler_biscuit_token_test))),
         )
-    ).await;
+        .await;
 
-    let req = test::TestRequest::get()
-      .uri("/test")
-      .to_request();
-    let resp = test::call_service(&app, req).await;
+        let req = test::TestRequest::get().uri("/test").to_request();
+        let resp = test::call_service(&app, req).await;
 
-    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
-  }
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
 
-  #[actix_web::test]
-  async fn test_incorrect_headers() {
-    let root = KeyPair::new();
-    let app = test::init_service(
-      App::new()
-        .wrap(BiscuitMiddleware{public_key: root.public()})
-        .service(
-          web::resource("/test")
-            .route(web::get().to(handler_biscuit_token_test))
+    #[actix_web::test]
+    async fn test_incorrect_headers() {
+        let root = KeyPair::new();
+        let app = test::init_service(
+            App::new()
+                .wrap(BiscuitMiddleware {
+                    public_key: root.public(),
+                })
+                .service(web::resource("/test").route(web::get().to(handler_biscuit_token_test))),
         )
-    ).await;
+        .await;
 
-    let req = test::TestRequest::get()
-      .insert_header((
-        "authorization",
-        "ééé"
-      ))
-      .uri("/test")
-      .to_request();
-    let resp = test::call_service(&app, req).await;
+        let req = test::TestRequest::get()
+            .insert_header(("authorization", "ééé"))
+            .uri("/test")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
 
-    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 
-    let req = test::TestRequest::get()
-      .insert_header((
-        "authorization",
-        "Accessible foo"
-      ))
-      .uri("/test")
-      .to_request();
-    let resp = test::call_service(&app, req).await;
+        let req = test::TestRequest::get()
+            .insert_header(("authorization", "Accessible foo"))
+            .uri("/test")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
 
-    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 
-    let req = test::TestRequest::get()
-      .insert_header((
-        "authorization",
-        "Bearer foo"
-      ))
-      .uri("/test")
-      .to_request();
-    let resp = test::call_service(&app, req).await;
+        let req = test::TestRequest::get()
+            .insert_header(("authorization", "Bearer foo"))
+            .uri("/test")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
 
-    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
-  }
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
 
-  async fn handler_biscuit_token_test(_: web::ReqData<Biscuit>) -> HttpResponse {
-    HttpResponse::Ok().finish()
-  }
+    async fn handler_biscuit_token_test(_: web::ReqData<Biscuit>) -> HttpResponse {
+        HttpResponse::Ok().finish()
+    }
 }


### PR DESCRIPTION
This enables CI checks on all PRs to main:

It makes sure:

- the code compiles
- there are no clippy warnings or errors
- the tests pass
- the `nominal.rs` example compiles and runs with no error
- the code is correctly formatted

In addition to enabling CI, I fixed the issues it detected:

- a few clippy warnings (unneeded use of `?` / use of `if let Err(_) = r` instead of `if r.is_err()`
- inconsistent formatting

Since there is a "reformat everything" commit, i have added it to a new file, `.git-blame-ignore-revs`, which instructs github to ignore it during blame. Local repositories can also use it by registering it with this command:

    git config blame.ignoreRevsFile .git-blame-ignore-revs