### PR TITLE
5 middleware configuration

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,6 +37,5 @@ jobs:
         cargo test --verbose
         cargo build --example readme
         cargo build --example readme --features tracing
-        cargo build --example error_handling
-      
+        cargo build --example configuration
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,5 +37,6 @@ jobs:
         cargo test --verbose
         cargo build --example readme
         cargo build --example readme --features tracing
+        cargo build --example error_handling
       
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,8 +268,7 @@ dependencies = [
 [[package]]
 name = "biscuit-auth"
 version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47033e72ae01c3bea9385503636ba8cf54083bd52df80eccee088f806d7a0b42"
+source = "git+https://github.com/Tipnos/biscuit-rust.git?branch=impl-box-root-key-provider#fca6c48a722de5941935b11a41bb3cfa40f0efcb"
 dependencies = [
  "base64 0.13.1",
  "biscuit-parser",
@@ -292,8 +291,7 @@ dependencies = [
 [[package]]
 name = "biscuit-parser"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a478329b2b23038692ea5b792b99984a5128ea644a35a58f647dc5554c3a5b2"
+source = "git+https://github.com/Tipnos/biscuit-rust.git?branch=impl-box-root-key-provider#fca6c48a722de5941935b11a41bb3cfa40f0efcb"
 dependencies = [
  "hex",
  "nom",
@@ -306,8 +304,7 @@ dependencies = [
 [[package]]
 name = "biscuit-quote"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df264964d58df014dbbb60ce879a7194aabcc8f34cb85ff69ef68a1940a3d0b"
+source = "git+https://github.com/Tipnos/biscuit-rust.git?branch=impl-box-root-key-provider#fca6c48a722de5941935b11a41bb3cfa40f0efcb"
 dependencies = [
  "biscuit-parser",
  "proc-macro-error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ dependencies = [
 [[package]]
 name = "biscuit-auth"
 version = "3.1.0"
-source = "git+https://github.com/Tipnos/biscuit-rust.git?branch=impl-box-root-key-provider#fca6c48a722de5941935b11a41bb3cfa40f0efcb"
+source = "git+https://github.com/Tipnos/biscuit-rust.git?branch=impl-box-root-key-provider#2ad3ceec29ae2979158cb63cbe91db3ff7d3afd6"
 dependencies = [
  "base64 0.13.1",
  "biscuit-parser",
@@ -291,7 +291,7 @@ dependencies = [
 [[package]]
 name = "biscuit-parser"
 version = "0.1.0"
-source = "git+https://github.com/Tipnos/biscuit-rust.git?branch=impl-box-root-key-provider#fca6c48a722de5941935b11a41bb3cfa40f0efcb"
+source = "git+https://github.com/Tipnos/biscuit-rust.git?branch=impl-box-root-key-provider#2ad3ceec29ae2979158cb63cbe91db3ff7d3afd6"
 dependencies = [
  "hex",
  "nom",
@@ -304,7 +304,7 @@ dependencies = [
 [[package]]
 name = "biscuit-quote"
 version = "0.2.1"
-source = "git+https://github.com/Tipnos/biscuit-rust.git?branch=impl-box-root-key-provider#fca6c48a722de5941935b11a41bb3cfa40f0efcb"
+source = "git+https://github.com/Tipnos/biscuit-rust.git?branch=impl-box-root-key-provider#2ad3ceec29ae2979158cb63cbe91db3ff7d3afd6"
 dependencies = [
  "biscuit-parser",
  "proc-macro-error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,8 +267,9 @@ dependencies = [
 
 [[package]]
 name = "biscuit-auth"
-version = "3.1.0"
-source = "git+https://github.com/Tipnos/biscuit-rust.git?branch=impl-box-root-key-provider#2ad3ceec29ae2979158cb63cbe91db3ff7d3afd6"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d1e91dedc0523e4ff74633d4bdac7251e40e0759f3e85f5f7995ff3c095c281"
 dependencies = [
  "base64 0.13.1",
  "biscuit-parser",
@@ -290,8 +291,9 @@ dependencies = [
 
 [[package]]
 name = "biscuit-parser"
-version = "0.1.0"
-source = "git+https://github.com/Tipnos/biscuit-rust.git?branch=impl-box-root-key-provider#2ad3ceec29ae2979158cb63cbe91db3ff7d3afd6"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f2fea7264a5bff6f3444b3b05da27ad332427f5267435e2efabaf0476e45bf"
 dependencies = [
  "hex",
  "nom",
@@ -304,7 +306,8 @@ dependencies = [
 [[package]]
 name = "biscuit-quote"
 version = "0.2.1"
-source = "git+https://github.com/Tipnos/biscuit-rust.git?branch=impl-box-root-key-provider#2ad3ceec29ae2979158cb63cbe91db3ff7d3afd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df264964d58df014dbbb60ce879a7194aabcc8f34cb85ff69ef68a1940a3d0b"
 dependencies = [
  "biscuit-parser",
  "proc-macro-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,17 @@ keywords = ["http", "actix-web", "biscuit", "token", "authorization"]
 categories = ["asynchronous", "web-programming"]
 
 [dependencies]
-actix-web = { version = "4.3.1", default-features = false, features = ["macros"] }
+actix-web = { version = "4.3.1", default-features = false, features = [
+    "macros",
+] }
 actix-web-httpauth = "0.8.0"
-biscuit-auth = { git = "https://github.com/Tipnos/biscuit-rust.git", branch="impl-box-root-key-provider" }
+biscuit-auth = { version = "3.2.0", default-features = false }
 derive_more = { version = "0.99.17", default-features = false }
-futures-util = {version = "0.3.28", default-features = false }
+futures-util = { version = "0.3.28", default-features = false }
 time = { version = "0.3.20", default-features = false }
 tracing = { version = "0.1.37", default-features = false, optional = true }
 
 [dev-dependencies]
-biscuit-auth = { git = "https://github.com/Tipnos/biscuit-rust.git", branch="impl-box-root-key-provider" }
+biscuit-auth = { version = "3.2.0" }
 tracing-actix-web = "0.7.3"
-tracing-subscriber = {version = "0.3.16", features = ["env-filter"]}
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,13 @@ categories = ["asynchronous", "web-programming"]
 [dependencies]
 actix-web = { version = "4.3.1", default-features = false, features = ["macros"] }
 actix-web-httpauth = "0.8.0"
-biscuit-auth = { version = "3.1.0", default-features = false }
+biscuit-auth = { git = "https://github.com/Tipnos/biscuit-rust.git", branch="impl-box-root-key-provider" }
 derive_more = { version = "0.99.17", default-features = false }
 futures-util = {version = "0.3.28", default-features = false }
 time = { version = "0.3.20", default-features = false }
 tracing = { version = "0.1.37", default-features = false, optional = true }
 
 [dev-dependencies]
-biscuit-auth = { version = "3.1.0" }
+biscuit-auth = { git = "https://github.com/Tipnos/biscuit-rust.git", branch="impl-box-root-key-provider" }
 tracing-actix-web = "0.7.3"
 tracing-subscriber = {version = "0.3.16", features = ["env-filter"]}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The middleware expects a base64-encoded token through the [bearer token HTTP aut
 - Requests without a bearer token are rejected with a HTTP `401 Unauthorized` error;
 - Requests with tokens that fail parsing or cryptographic verification are rejected with a HTTP `403 Forbidden` error.
 
-Token extraction logic, token parsing logic and error handling are not configurable yet.
+Token extraction logic and error handling is configurable (see [Configuration example](./examples/configuration.rs)).
 
 ## Working example
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The middleware expects a base64-encoded token through the [bearer token HTTP aut
 - Requests without a bearer token are rejected with a HTTP `401 Unauthorized` error;
 - Requests with tokens that fail parsing or cryptographic verification are rejected with a HTTP `403 Forbidden` error.
 
-Token extraction logic and error handling is configurable (see [Configuration example](./examples/configuration.rs)).
+Token extraction logic and error handling are configurable (see [Configuration example](./examples/configuration.rs)).
 
 ## Working example
 

--- a/examples/configuration.rs
+++ b/examples/configuration.rs
@@ -42,14 +42,14 @@ Because of custom configuration, the token has to be set in the biscuit header:
                     .token_extractor(|req: &ServiceRequest| {
                         println!("Extracting token with custom extractor");
 
-                        Ok(req
-                            .headers()
-                            .get("biscuit")
-                            .ok_or(())?
-                            .to_str()
-                            .map_err(|_| ())?
-                            .to_string()
-                            .into_bytes())
+                        Some(
+                            req.headers()
+                                .get("biscuit")?
+                                .to_str()
+                                .ok()?
+                                .to_string()
+                                .into_bytes(),
+                        )
                     }),
             )
             .service(hello)

--- a/examples/error_handling.rs
+++ b/examples/error_handling.rs
@@ -1,0 +1,108 @@
+use actix_web::{get, web, App, HttpResponse, HttpServer};
+use biscuit_actix_middleware::BiscuitMiddleware;
+use biscuit_auth::{macros::*, Biscuit, PublicKey};
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    let public_key = PublicKey::from_bytes_hex(
+        &std::env::var("BISCUIT_PUBLIC_KEY")
+            .expect("Missing BISCUIT_PUBLIC_KEY environment variable. You can fix it by using the following command to run the example: BISCUIT_PUBLIC_KEY=2d6a07768e5768192870f91a6949cd09ce49865f2e2eb1241369c300ee7cc21f cargo run --example error_handling"),
+    )
+    .expect("Couldn't parse public key");
+
+    println!(
+        r#"
+This server exposes a single endpoint on `GET /hello`.
+The whole server requires a valid biscuit token. Its signature is verified
+by a public key provided through the `BISCUIT_PUBLIC_KEY` environment variable.
+The `GET /hello` endpoints expects a token containg `role("admin");`.
+
+You can generate a keypair and a token with the biscuit CLI:
+> biscuit keypair # generates a key pair
+> echo 'role("admin");' | biscuit generate --private-key <the private key> -
+
+You can also use the following:
+
+  public key: 2d6a07768e5768192870f91a6949cd09ce49865f2e2eb1241369c300ee7cc21f
+  token: EnYKDBgDIggKBggGEgIYDRIkCAASIDZy3NpVVceLLr5Xqcv08H7BeBQry38djs13jJz6uDxVGkBWQyFbDLPYaEo1PMZxB6In0mbYFiAjWEJfd2kr7P2qu8YQDNCoyIBsRP4A-4OzfvzFr2o3x9b7jOHksiRxbpILIiIKIITNLF9dFYE_tbpsqBEgno0bbwLi56dvpM43SaK7o8Iu
+
+The token has to be set in the authorization header:
+
+  curl -v http://localhost:8080/hello \
+    -H "Authorization: Bearer <token>"
+"#
+    );
+
+    println!("Starting server on 127.0.0.1:8080");
+    HttpServer::new(move || {
+        App::new()
+            .wrap(
+                BiscuitMiddleware::new(public_key)
+                    .error_handler(error::middleware_app_error_handler),
+            )
+            .service(hello)
+    })
+    .bind(("127.0.0.1", 8080))?
+    .run()
+    .await
+}
+
+#[get("/hello")]
+async fn hello(biscuit: web::ReqData<Biscuit>) -> HttpResponse {
+    let mut authorizer = authorizer!(
+        r#"
+      allow if role("admin");
+    "#
+    );
+
+    authorizer.add_token(&biscuit).unwrap();
+    if let Err(_e) = authorizer.authorize() {
+        return HttpResponse::Forbidden().finish();
+    }
+
+    HttpResponse::Ok().body("Hello admin!")
+}
+
+mod error {
+    use actix_web::{dev::ServiceRequest, HttpResponse, ResponseError};
+    use biscuit_actix_middleware::error::*;
+    use derive_more::Display;
+
+    #[derive(Debug, Display)]
+    pub enum AppError {
+        TokenMissing,
+        Forbidden,
+    }
+
+    impl ResponseError for AppError {
+        fn error_response(&self) -> HttpResponse {
+            match self {
+                AppError::TokenMissing => HttpResponse::Unauthorized().finish(),
+                AppError::Forbidden => HttpResponse::Forbidden().finish(),
+            }
+        }
+    }
+
+    // ResponseError handler
+    pub fn middleware_app_error_handler<'a>(
+        err: MiddlewareError,
+        _: &'a ServiceRequest,
+    ) -> MiddlewareErrorResponse {
+        MiddlewareErrorResponse::ResponseError(match err {
+            MiddlewareError::InvalidHeader => Box::new(AppError::TokenMissing),
+            MiddlewareError::InvalidToken => {
+                // Eventually trace caller IP to detect brut force attack
+                Box::new(AppError::Forbidden)
+            }
+        })
+    }
+
+    #[allow(dead_code)]
+    // HttpResponse handler
+    pub fn middleware_raw_error_handler<'a>(
+        _: MiddlewareError,
+        _: &'a ServiceRequest,
+    ) -> MiddlewareErrorResponse {
+        MiddlewareErrorResponse::HttpResponse(HttpResponse::Unauthorized().finish())
+    }
+}

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -43,7 +43,7 @@ The token has to be set in the authorization header:
     println!("Starting server on 127.0.0.1:8080");
     HttpServer::new(move || {
         let app = App::new()
-            .wrap(BiscuitMiddleware { public_key })
+            .wrap(BiscuitMiddleware::new(public_key))
             .service(hello);
 
         #[cfg(feature = "tracing")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,12 @@
 use actix_web::{error::ResponseError, HttpResponse};
 use derive_more::Display;
 
-pub type MiddlewareResult<R> = Result<R, MiddlewareError>;
+pub(crate) type MiddlewareResult<R> = Result<R, HttpResponse>;
+
+pub enum MiddlewareErrorResponse {
+    ResponseError(Box<dyn ResponseError>),
+    HttpResponse(HttpResponse),
+}
 
 #[derive(Debug, Display)]
 pub enum MiddlewareError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,11 +3,6 @@ use derive_more::Display;
 
 pub(crate) type MiddlewareResult<R> = Result<R, HttpResponse>;
 
-pub enum MiddlewareErrorResponse {
-    ResponseError(Box<dyn ResponseError>),
-    HttpResponse(HttpResponse),
-}
-
 #[derive(Debug, Display)]
 pub enum MiddlewareError {
     InvalidHeader,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-mod error;
+pub mod error;
 mod middleware;
 
 extern crate biscuit_auth as biscuit;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -125,14 +125,6 @@ impl BiscuitMiddleware {
     ///
     /// let key_provider = KeyProvider::new();
     ///
-    /// let mut builder = Biscuit::builder();
-    /// builder.set_root_key_id(2);
-    ///
-    /// let biscuit = builder.build(&key_provider.roots[2]).unwrap();
-    ///
-    /// assert!(Biscuit::from_base64(biscuit.to_base64().unwrap(), &key_provider).is_ok());
-    /// assert!(Biscuit::from_base64(biscuit.to_base64().unwrap(), &KeyPair::new().public()).is_err());
-    ///
     /// let middleware = BiscuitMiddleware::new(key_provider);
     /// ```
     pub fn new<KP>(public_key: KP) -> BiscuitMiddleware

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -268,7 +268,7 @@ impl<S> ImplBiscuitMiddleware<S> {
             .ok_or((self.error_handler)(MiddlewareError::InvalidHeader, req))?;
 
         // Parse token
-        Biscuit::from_base64(token, &self.public_key).map_err(|_e| {
+        Biscuit::from_base64(token, self.public_key.clone()).map_err(|_e| {
             #[cfg(feature = "tracing")]
             warn!("{}", _e.to_string());
             (self.error_handler)(MiddlewareError::InvalidToken, req)

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -142,20 +142,7 @@ impl BiscuitMiddleware {
         BiscuitMiddleware {
             public_key: Rc::new(public_key),
             error_handler: |err: MiddlewareError, _: &ServiceRequest| err.error_response(),
-            token_extractor: |req: &ServiceRequest| {
-                Some(
-                    Authorization::<Bearer>::parse(req)
-                        .map_err(|_e| {
-                            #[cfg(feature = "tracing")]
-                            warn!("{}", _e.to_string());
-                        })
-                        .ok()?
-                        .as_ref()
-                        .token()
-                        .to_string()
-                        .into_bytes(),
-                )
-            },
+            token_extractor: Self::token_extractor_default,
         }
     }
 
@@ -227,6 +214,22 @@ impl BiscuitMiddleware {
         self.token_extractor = extractor;
 
         self
+    }
+
+    /// Middleware default token extraction logic. It can be use as a base of a [custom token extractor](BiscuitMiddleware#method.token_extractor) to add pre/post processing to token extraction.
+    pub fn token_extractor_default(req: &ServiceRequest) -> Option<Vec<u8>> {
+        Some(
+            Authorization::<Bearer>::parse(req)
+                .map_err(|_e| {
+                    #[cfg(feature = "tracing")]
+                    warn!("{}", _e.to_string());
+                })
+                .ok()?
+                .as_ref()
+                .token()
+                .to_string()
+                .into_bytes(),
+        )
     }
 }
 

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -88,7 +88,7 @@ impl BiscuitMiddleware {
         }
     }
 
-    /// Add a custom error handler to an existing middleware.
+    /// Add a custom error handler to customize HttpResponses according to [MiddlewareError] and [ServiceRequest] params
     ///
     /// # Example
     /// ```rust
@@ -132,9 +132,7 @@ impl BiscuitMiddleware {
     }
 
     /// Add a custom token extractor to an existing middleware.
-    /// The [Result] error type is voluntarily () to rely on middleware or an [ErrorHandler] implementation to define
-    /// invalid header behavior.
-    ///
+    /// The [Result] error type is `()` to keep error messages vague. To customize middleware errors [HttpResponse] see [BiscuitMiddleware::error_handler](BiscuitMiddleware#method.error_handler) method.
     ///
     /// # Example
     /// ```rust

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -92,7 +92,7 @@ impl BiscuitMiddleware {
     /// BiscuitMiddleware::new(KeyPair::new().public());
     /// ```
     ///
-    /// Setup a simple KeyProvider that only accept token with a root_key_id corresponding to an index of an existing [PublicKey](biscuit_auth::PublicKey)
+    /// Setup a simple KeyProvider that only accepts tokens with a root_key_id corresponding to an index of an existing [PublicKey](biscuit_auth::PublicKey)
     /// ```rust
     /// use biscuit_auth::{error::Format, Biscuit, KeyPair, PublicKey, RootKeyProvider};
     /// use biscuit_actix_middleware::BiscuitMiddleware;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -142,7 +142,7 @@ impl BiscuitMiddleware {
         BiscuitMiddleware {
             public_key: Rc::new(public_key),
             error_handler: |err: MiddlewareError, _: &ServiceRequest| err.error_response(),
-            token_extractor: Self::token_extractor_default,
+            token_extractor: Self::default_token_extractor,
         }
     }
 
@@ -217,7 +217,7 @@ impl BiscuitMiddleware {
     }
 
     /// Middleware default token extraction logic. It can be use as a base of a [custom token extractor](BiscuitMiddleware#method.token_extractor) to add pre/post processing to token extraction.
-    pub fn token_extractor_default(req: &ServiceRequest) -> Option<Vec<u8>> {
+    pub fn default_token_extractor(req: &ServiceRequest) -> Option<Vec<u8>> {
         Some(
             Authorization::<Bearer>::parse(req)
                 .map_err(|_e| {

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -82,7 +82,9 @@ impl BiscuitMiddleware {
     /// If either selection or rotation are not required, you can pass a [PublicKey](biscuit::PublicKey) (it already implements [RootKeyProvider] in [biscuit-auth](biscuit) lib).
     ///
     /// # Examples
+    ///
     /// Selection and rotation are not required
+    ///
     /// ```rust
     /// use biscuit_actix_middleware::BiscuitMiddleware;
     /// use biscuit_auth::KeyPair;


### PR DESCRIPTION
Implementation proposal for https://github.com/biscuit-auth/biscuit-actix-middleware/issues/5.

As discussed with @divarvel, token parsing feature is no more mandatory. Consequently, this PR add following configuration:
- Error handling
- Token extraction 
- Public key selection/rotation management

At the moment of writing, the `biscuit-auth` dependency points to a branch of my fork. If my proposal is validated, we have to merge my branch to `biscuit-auth` repo, then update `cargo.toml`  before merging the PR.