### PR TITLE
fix readme example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "biscuit-actix-middleware"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "actix-web",
  "actix-web-httpauth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "biscuit-actix-middleware"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ async fn main() -> std::io::Result<()> {
 
     HttpServer::new(move || {
         App::new()
-            .wrap(BiscuitMiddleware { public_key })
+            .wrap(BiscuitMiddleware::new(public_key))
             .service(hello)
     })
     .bind(("127.0.0.1", 8080))?


### PR DESCRIPTION
While using the middleware in a test project, I saw README example was not properly updated in last merge request. This PR fixes it.